### PR TITLE
Set permission for /dev/pn544

### DIFF
--- a/rootdir/etc/ueventd.g3.rc
+++ b/rootdir/etc/ueventd.g3.rc
@@ -179,6 +179,7 @@
 
 # nfc permissions
 /dev/pn547                0660   nfc        nfc
+/dev/pn544                0660   nfc        nfc
 
 # UIO devices
 /dev/uio0                 0660   system     system


### PR DESCRIPTION
This is needed for nfc support on ls990

Change-Id: I385229ab8f92c9c2ca9971c6613a3bf2598a3b97